### PR TITLE
OS-637: Set default citizenship value

### DIFF
--- a/src/HEd/Bundle/StudentBundle/Resources/config/schema/student.yml
+++ b/src/HEd/Bundle/StudentBundle/Resources/config/schema/student.yml
@@ -158,6 +158,7 @@ HEd.Student:
       db_column_name: CITIZENSHIP_COUNTRY
       db_column_type: varchar
       db_column_length: 2
+      db_column_default: "US"
       db_column_null: true
       field_type: lookup
       lookup: Constituent.Address.Country


### PR DESCRIPTION
Set the default citizenship value for Students to be the United States (`US`).

Pulled the `US` value from `Constituent.Address.Country` values.