### PR TITLE
SIS-464: Rename "Notes" to "Internal Notes"

### DIFF
--- a/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
+++ b/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
@@ -18,7 +18,7 @@
 <div class="group-box">
 <div class="group-box-header">Internal Notes</div>
 <div class="group-box-contents group">
-<p>These are administrative, internal notes. They are not available through API clients (such as Drupal) and are meant for administrative.</p>
+<p>These are administrative, internal notes. They are not available through API clients (such as Drupal).</p>
 {{ kula_field({ edit: true, field: 'Core.Constituent.Notes', db_row_id: student.STUDENT_ID, value: student.NOTES, label: true, attributes_html: { rows: 20 }}) }}
 </div>
 </div>

--- a/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
+++ b/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
@@ -16,8 +16,9 @@
 </div>
 </div>
 <div class="group-box">
-<div class="group-box-header">Notes</div>
+<div class="group-box-header">Internal Notes</div>
 <div class="group-box-contents group">
+<p>These are administrative, internal notes. They are not available through API clients (such as Drupal) and are meant for administrative.</p>
 {{ kula_field({ edit: true, field: 'Core.Constituent.Notes', db_row_id: student.STUDENT_ID, value: student.NOTES, label: true, attributes_html: { rows: 20 }}) }}
 </div>
 </div>


### PR DESCRIPTION
## Changes Made
* Renamed `Notes` to `Internal Notes` and added helper text to clarify the fields purpose.

## Instructions to QA
* Navigate to the **Other Info** tab on the Student section and confirm that you see **Internal Notes** rather than **Notes**.

![screen shot 2018-01-17 at 10 09 24 pm](https://user-images.githubusercontent.com/918979/35083269-19680d86-fbd3-11e7-8234-e86a6addcf13.png)
