### PR TITLE
SIS-465: Set deprecation notice for "Community Programs" section in Other Info

### DIFF
--- a/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
+++ b/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
@@ -24,6 +24,7 @@
 <div class="group-box">
 <div class="group-box-header">Community Programs</div>
 <div class="group-box-contents group">
+<p style="color:red;"><strong>DEPRECATION NOTICE:</strong> Effective 4/1/2018, this section will be removed. To access these specific fields, please use the <em>User Info</em> tab above. No data will be lost in this removal.</p>
 {% if student_status.STUDENT_STATUS_ID %}
   {{ kula_field({ edit: true, field: 'HEd.Student.Status.School', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.SCHOOL, label: true}) }}
   {{ kula_field({ edit: true, field: 'HEd.Student.Status.GroupWith', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.GROUP_WITH, label: true}) }}


### PR DESCRIPTION
## Changes Made
* Add in the initial deprecation notice for the Community Programs section.

## Instructions to QA
* Navigate to the `Other Info` section and verify that you see a red deprecation section of an April 1, 2018 cutoff.

![screen shot 2018-01-17 at 10 08 36 pm](https://user-images.githubusercontent.com/918979/35083237-fb6aa3a2-fbd2-11e7-830d-cce6193a83eb.png)
