### PR TITLE
SIS-465: Remove the Community Programs section completely

### DIFF
--- a/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
+++ b/src/HEd/Bundle/StudentBundle/Resources/views/CoreInformation/other_info.html.twig
@@ -22,18 +22,6 @@
 </div>
 </div>
 <div class="group-box">
-<div class="group-box-header">Community Programs</div>
-<div class="group-box-contents group">
-{% if student_status.STUDENT_STATUS_ID %}
-  {{ kula_field({ edit: true, field: 'HEd.Student.Status.School', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.SCHOOL, label: true}) }}
-  {{ kula_field({ edit: true, field: 'HEd.Student.Status.GroupWith', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.GROUP_WITH, label: true}) }}
-  {{ kula_field({ edit: true, field: 'HEd.Student.Status.OffCampus', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.OFF_CAMPUS, label: true}) }}
-  {{ kula_field({ edit: true, field: 'HEd.Student.Status.ShirtSize', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.SHIRT_SIZE, label: true}) }}
-  {{ kula_field({ edit: true, field: 'HEd.Student.Status.Age', db_row_id: student_status.STUDENT_STATUS_ID, value: student_status.AGE, label: true}) }}
-{% endif %}
-</div>
-</div>
-<div class="group-box">
 <div class="group-box-header">Medical/Allergy</div>
 <div class="group-box-contents group">
 {{ kula_field({ edit: true, field: 'HEd.Student.MedicalNotes', db_row_id: student.STUDENT_ID, value: student.MEDICAL_NOTES, label: true}) }}


### PR DESCRIPTION
## Changes Made
* After a conversation with Community Programs and since the data is available on the **User Info** tab we can just remove this section completely.
* This replaces #44.

## Instructions to QA
* Navigate to the `Other Info` section and verify that you do not see the **Community Programs** field group.